### PR TITLE
[GP-3] Validate all requests

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Http\Requests\RegisterRequest;
 use App\Interfaces\Services\IAuthService;
 use Illuminate\Http\{JsonResponse, Request};
 use Symfony\Component\HttpFoundation\Response as StatusCode;
@@ -34,7 +35,7 @@ class AuthController extends Controller
         return response()->json(status: StatusCode::HTTP_OK);
     }
 
-    public function register(Request $request): JsonResponse
+    public function register(RegisterRequest $request): JsonResponse
     {
         $user = $this->authService->register($request->all());
 

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Controllers;
 
-use App\Http\Requests\RegisterRequest;
+use App\Http\Requests\{LoginRequest, RegisterRequest};
 use App\Interfaces\Services\IAuthService;
 use Illuminate\Http\{JsonResponse, Request};
 use Symfony\Component\HttpFoundation\Response as StatusCode;
@@ -16,7 +16,7 @@ class AuthController extends Controller
         $this->authService = $authService;
     }
 
-    public function login(Request $request): JsonResponse
+    public function login(LoginRequest $request): JsonResponse
     {
         try {
             $credentials = $request->only('email', 'password');

--- a/app/Http/Requests/LoginRequest.php
+++ b/app/Http/Requests/LoginRequest.php
@@ -22,7 +22,7 @@ class LoginRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'email' => 'exists:users',
+            'email' => 'required|exists:users|email:rfc,dns',
         ];
     }
 
@@ -30,6 +30,7 @@ class LoginRequest extends FormRequest
     {
         return [
             'email.exists' => 'Invalid credentials.',
+            'email.email'  => 'Invalid credentials.',
         ];
     }
 }

--- a/app/Http/Requests/LoginRequest.php
+++ b/app/Http/Requests/LoginRequest.php
@@ -22,15 +22,17 @@ class LoginRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'email' => 'required|exists:users|email:rfc',
+            'email'    => 'required|exists:users|email:rfc',
+            'password' => 'required',
         ];
     }
 
     public function messages(): array
     {
         return [
-            'email.exists' => 'Invalid credentials.',
-            'email.email'  => 'Invalid credentials.',
+            'email.exists'      => 'Invalid credentials.',
+            'email.email'       => 'Invalid credentials.',
+            'password.required' => 'Invalid credentials.',
         ];
     }
 }

--- a/app/Http/Requests/LoginRequest.php
+++ b/app/Http/Requests/LoginRequest.php
@@ -22,7 +22,7 @@ class LoginRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'email' => 'required|exists:users|email:rfc,dns',
+            'email' => 'required|exists:users|email:rfc',
         ];
     }
 

--- a/app/Http/Requests/LoginRequest.php
+++ b/app/Http/Requests/LoginRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class LoginRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => 'exists:users',
+        ];
+    }
+
+    public function messages(): array
+    {
+        return [
+            'email.exists' => 'Invalid credentials.',
+        ];
+    }
+}

--- a/app/Http/Requests/RegisterRequest.php
+++ b/app/Http/Requests/RegisterRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class RegisterRequest extends FormRequest
+{
+    /**
+     * Determine if the user is authorized to make this request.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array<string, \Illuminate\Contracts\Validation\ValidationRule|array<mixed>|string>
+     */
+    public function rules(): array
+    {
+        return [
+            'email' => 'required|email:rfc,dns|unique:users,email',
+        ];
+    }
+}

--- a/app/Http/Requests/RegisterRequest.php
+++ b/app/Http/Requests/RegisterRequest.php
@@ -22,6 +22,7 @@ class RegisterRequest extends FormRequest
     public function rules(): array
     {
         return [
+            'name'  => 'required',
             'email' => 'required|email:rfc,dns|unique:users,email',
         ];
     }

--- a/tests/Feature/Auth/AuthControllerTest.php
+++ b/tests/Feature/Auth/AuthControllerTest.php
@@ -33,7 +33,7 @@ it('should make sure to inform the user an error when email and password doesnt 
         'password' => 'password',
     ]);
 
-    expect($response->status())->toBe(401);
+    expect($response->status())->toBe(422);
     expect($response->json('message'))->toBe('Invalid credentials.');
     expect(auth()->check())->toBeFalse();
 });

--- a/tests/Feature/Auth/AuthControllerTest.php
+++ b/tests/Feature/Auth/AuthControllerTest.php
@@ -55,7 +55,7 @@ it('should be able to logout of the application', function () {
 
 it('should be able to register a new user in the application', function () {
     $name  = $this->faker->name;
-    $email = $this->faker->unique()->safeEmail;
+    $email = $this->faker->unique()->freeEmail;
 
     $payload = [
         'name'                  => $name,
@@ -83,7 +83,7 @@ test('should send a email to new user', function () {
 
     $payload = [
         'name'                  => $this->faker->name,
-        'email'                 => $this->faker->unique()->safeEmail,
+        'email'                 => $this->faker->unique()->freeEmail,
         'password'              => 'password',
         'password_confirmation' => 'password',
     ];

--- a/tests/Unit/Auth/LoginTest.php
+++ b/tests/Unit/Auth/LoginTest.php
@@ -3,6 +3,8 @@
 use App\Models\User;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Foundation\Testing\{RefreshDatabase, TestCase};
+use Illuminate\Support\Facades\Hash;
+use Nette\Utils\Random;
 
 use function Pest\Laravel\{postJson};
 
@@ -19,5 +21,18 @@ it('should not be possible to log in to a user if the email is not registered', 
     expect($response->status())->toBe(422);
 
     $response->assertStatus(422);
+    expect($response->json("message"))->toContain("Invalid credentials.");
+});
+
+it('should not be possible to log in to a user if the password is is incorrect', function () {
+    $randomPassword = Hash::make(Random::generate());
+    $user           = User::factory()->create(['password' => $randomPassword]);
+
+    $response = postJson('/api/v1/login', [
+        'email'    => $user->email,
+        'password' => 'password',
+    ]);
+
+    $response->assertStatus(status: 401);
     expect($response->json("message"))->toContain("Invalid credentials.");
 });

--- a/tests/Unit/Auth/LoginTest.php
+++ b/tests/Unit/Auth/LoginTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\{RefreshDatabase, TestCase};
+
+use function Pest\Laravel\{postJson};
+
+uses(TestCase::class, RefreshDatabase::class, WithFaker::class);
+
+it('should not be possible to log in to a user if the email is not registered', function () {
+    $user = User::factory()->create();
+
+    $response = postJson('/api/v1/login', [
+        'email'    => 'thisemailnotexists@notexists.com',
+        'password' => 'password',
+    ]);
+
+    expect($response->status())->toBe(422);
+
+    $response->assertStatus(422);
+    expect($response->json("message"))->toContain("Invalid credentials.");
+});

--- a/tests/Unit/Auth/RegisterTest.php
+++ b/tests/Unit/Auth/RegisterTest.php
@@ -26,3 +26,22 @@ it('should not be possible to register a new user if the email is invalid', func
 
     assertDatabaseCount('users', 0);
 });
+
+it('should not be possible to register a new user if the email is null', function () {
+    $name = $this->faker->name;
+
+    $payload = [
+        'name'                  => $name,
+        'email'                 => '',
+        'password'              => 'password',
+        'password_confirmation' => 'password',
+    ];
+
+    $response = postJson('/api/v1/register', $payload);
+
+    $response->assertStatus(422);
+    expect($response->json("message"))->toContain("The email field is required.");
+    ;
+
+    assertDatabaseCount('users', 0);
+});

--- a/tests/Unit/Auth/RegisterTest.php
+++ b/tests/Unit/Auth/RegisterTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Foundation\Testing\WithFaker;
+use Illuminate\Foundation\Testing\{RefreshDatabase, TestCase};
+
+use function Pest\Laravel\{assertDatabaseCount, postJson};
+
+uses(TestCase::class, RefreshDatabase::class, WithFaker::class);
+
+it('should not be possible to register a new user if the email is invalid', function () {
+    $name  = $this->faker->name;
+    $email = str($this->faker->email)->replace('.com', '');
+
+    $payload = [
+        'name'                  => $name,
+        'email'                 => $email,
+        'password'              => 'password',
+        'password_confirmation' => 'password',
+    ];
+
+    $response = postJson('/api/v1/register', $payload);
+
+    $response->assertStatus(422);
+    expect($response->json("message"))->toContain("The email field must be a valid email address");
+    ;
+
+    assertDatabaseCount('users', 0);
+});

--- a/tests/Unit/Auth/RegisterTest.php
+++ b/tests/Unit/Auth/RegisterTest.php
@@ -9,7 +9,7 @@ uses(TestCase::class, RefreshDatabase::class, WithFaker::class);
 
 it('should not be possible to register a new user if the email is invalid', function () {
     $name  = $this->faker->name;
-    $email = str($this->faker->email)->replace('.com', '');
+    $email = str($this->faker->unique()->email)->replace('.com', '');
 
     $payload = [
         'name'                  => $name,

--- a/tests/Unit/Auth/RegisterTest.php
+++ b/tests/Unit/Auth/RegisterTest.php
@@ -22,7 +22,6 @@ it('should not be possible to register a new user if the email is invalid', func
 
     $response->assertStatus(422);
     expect($response->json("message"))->toContain("The email field must be a valid email address");
-    ;
 
     assertDatabaseCount('users', 0);
 });
@@ -41,7 +40,26 @@ it('should not be possible to register a new user if the email is null', functio
 
     $response->assertStatus(422);
     expect($response->json("message"))->toContain("The email field is required.");
-    ;
 
     assertDatabaseCount('users', 0);
+});
+
+it('should not be possible to register a new user if the email is not unique', function () {
+    $name  = $this->faker->name;
+    $email = str($this->faker->unique()->freeEmail);
+
+    $payload = [
+        'name'                  => $name,
+        'email'                 => $email,
+        'password'              => 'password',
+        'password_confirmation' => 'password',
+    ];
+
+    $response = postJson('/api/v1/register', $payload);
+    $response = postJson('/api/v1/register', $payload);
+
+    $response->assertStatus(422);
+    expect($response->json("message"))->toContain("The email has already been taken.");
+
+    assertDatabaseCount('users', 1);
 });

--- a/tests/Unit/Auth/RegisterTest.php
+++ b/tests/Unit/Auth/RegisterTest.php
@@ -63,3 +63,22 @@ it('should not be possible to register a new user if the email is not unique', f
 
     assertDatabaseCount('users', 1);
 });
+
+it('should not be possible to register a new user if the name is null', function () {
+    $email = str($this->faker->unique()->freeEmail);
+
+    $payload = [
+        'name'                  => '',
+        'email'                 => $email,
+        'password'              => 'password',
+        'password_confirmation' => 'password',
+    ];
+
+    $response = postJson('/api/v1/register', $payload);
+    $response = postJson('/api/v1/register', $payload);
+
+    $response->assertStatus(422);
+    expect($response->json("message"))->toContain("The name field is required.");
+
+    assertDatabaseCount('users', 0);
+});


### PR DESCRIPTION
- **gp-3: should not be possible to register a new user if the email is invalid**
- **gp-3: resolve tests with new validations**
- **gp-3: should not be possible to register a new user if the email is null**
- **gp-3: should not be possible to register a new user if the email is not unique**
- **gp-3: should not be possible to register a new user if the name is null**
- **gp-3: should not be possible to log in to a user if the email is not registered**
- **gp-3: adding more email rules for login**
- **gp-3: altering email rules for login**
- **gp-3: should not be possible to log in to a user if the password is is incorrect**
